### PR TITLE
Add string padding

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -52,4 +52,20 @@ umlaut.filter = (array, func) ->
 
   returnArray
 
+umlaut.padLeft = (string, len, char = ' ') ->
+  array = string.split('')
+
+  for [1..len]
+    array.unshift(char)
+
+  return array.join('')
+
+umlaut.padRight = (string, len, char = ' ') ->
+  array = string.split('')
+
+  for [1..len]
+    array.push(char)
+
+  return array.join('')
+
 module.exports = umlaut

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -50,3 +50,25 @@ describe "filter", ->
     result = umlaut.filter(arr, (item) -> item % 2 == 0)
 
     assert.deepEqual(result, [])
+
+describe "padLeft", ->
+  it "returns the string padded with spaces if no padding char is given", ->
+    result = umlaut.padLeft('hello', 3)
+
+    assert.equal(result, '   hello')
+
+  it "returns the string padded with the given char", ->
+    result = umlaut.padLeft('hello', 3, 'y')
+
+    assert.equal(result, 'yyyhello')
+
+describe "padRight", ->
+  it "returns the string padded with spaces if no padding char is given", ->
+    result = umlaut.padRight('hello', 3)
+
+    assert.equal(result, 'hello   ')
+
+  it "returns the string padded with the given char", ->
+    result = umlaut.padRight('hello', 3, 'y')
+
+    assert.equal(result, 'helloyyy')


### PR DESCRIPTION
In light of recent NPM drama, this library can be future-proofed by rolling it's own poorly implemented string padding functions.

`padLeft` and `padRight` included.
