### PR TITLE
make padLeft and padRight more webscale

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -52,20 +52,54 @@ umlaut.filter = (array, func) ->
 
   returnArray
 
-umlaut.padLeft = (string, len, char = ' ') ->
-  array = string.split('')
+exists       = require('exists')
+f            = require('false')
+is0          = require('is-zero')
+addOne       = require('add-one')
+toString     = require('to-string-x')
+isNullLike   = require('is-null-like')
+stringLength = require('string-length')
+lessThan     = require('validate.io-less-than')
+subtract     = require('formula-subtract')
+add          = require('lodash.add')
 
-  for [1..len]
-    array.unshift(char)
+umlaut.padLeft = (str, len, char) ->
+  if isNullLike(str)
+    throw new Error("'str' is required for padLeft")
 
-  return array.join('')
+  if isNullLike(len)
+    throw new Error("'len' is required for padLeft")
 
-umlaut.padRight = (string, len, char = ' ') ->
-  array = string.split('')
+  if !exists(char) && is0.isZero(char) == f()
+    char = ' '
 
-  for [1..len]
-    array.push(char)
+  str = toString(str)
+  len = subtract(len, stringLength(str))
+  i = -1
 
-  return array.join('')
+  while lessThan((i = addOne(i)), len)
+    str = add(char, str)
+
+  return str
+
+umlaut.padRight = (str, len, char) ->
+  if isNullLike(str)
+    throw new Error("'str' is required for padRight")
+
+  if isNullLike(len)
+    throw new Error("'len' is required for padRight")
+
+  if !exists(char) && is0.isZero(char) == f()
+    char = ' '
+
+  str = toString(str)
+  i = len
+  strLength = stringLength(str)
+
+  while lessThan(strLength, i)
+    str = add(str, char)
+    i = subtract(i, 1)
+
+  return str
 
 module.exports = umlaut

--- a/index.coffee
+++ b/index.coffee
@@ -62,6 +62,7 @@ stringLength = require('string-length')
 lessThan     = require('validate.io-less-than')
 subtract     = require('formula-subtract')
 add          = require('lodash.add')
+isNot        = require('not')
 
 umlaut.padLeft = (str, len, char) ->
   if isNullLike(str)
@@ -70,7 +71,7 @@ umlaut.padLeft = (str, len, char) ->
   if isNullLike(len)
     throw new Error("'len' is required for padLeft")
 
-  if !exists(char) && is0.isZero(char) == f()
+  if isNot(-> exists(char))() && is0.isZero(char) == f()
     char = ' '
 
   str = toString(str)
@@ -89,7 +90,7 @@ umlaut.padRight = (str, len, char) ->
   if isNullLike(len)
     throw new Error("'len' is required for padRight")
 
-  if !exists(char) && is0.isZero(char) == f()
+  if isNot(-> exists(char))() && is0.isZero(char) == f()
     char = ' '
 
   str = toString(str)

--- a/index.coffee
+++ b/index.coffee
@@ -63,6 +63,7 @@ lessThan     = require('validate.io-less-than')
 subtract     = require('formula-subtract')
 add          = require('lodash.add')
 isNot        = require('not')
+equals       = require('is-equal-shallow')
 
 umlaut.padLeft = (str, len, char) ->
   if isNullLike(str)
@@ -71,7 +72,7 @@ umlaut.padLeft = (str, len, char) ->
   if isNullLike(len)
     throw new Error("'len' is required for padLeft")
 
-  if isNot(-> exists(char))() && is0.isZero(char) == f()
+  if isNot(-> exists(char))() && equals(is0.isZero(char), f())
     char = ' '
 
   str = toString(str)
@@ -90,7 +91,7 @@ umlaut.padRight = (str, len, char) ->
   if isNullLike(len)
     throw new Error("'len' is required for padRight")
 
-  if isNot(-> exists(char))() && is0.isZero(char) == f()
+  if isNot(-> exists(char))() && equals(is0.isZero(char), f())
     char = ' '
 
   str = toString(str)

--- a/package.json
+++ b/package.json
@@ -22,7 +22,17 @@
   },
   "homepage": "https://github.com/umlautio/umlaut#readme",
   "dependencies": {
+    "add-one": "^1.0.3",
     "coffee-script": "^1.10.0",
-    "mocha": "^2.4.5"
+    "exists": "^1.0.0",
+    "false": "0.0.4",
+    "formula-subtract": "^1.0.0",
+    "is-null-like": "^1.0.3",
+    "is-zero": "^0.1.1",
+    "lodash.add": "^3.4.3",
+    "mocha": "^2.4.5",
+    "string-length": "^1.0.1",
+    "to-string-x": "^1.0.5",
+    "validate.io-less-than": "^1.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "is-zero": "^0.1.1",
     "lodash.add": "^3.4.3",
     "mocha": "^2.4.5",
+    "not": "^0.1.0",
     "string-length": "^1.0.1",
     "to-string-x": "^1.0.5",
     "validate.io-less-than": "^1.0.2"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "exists": "^1.0.0",
     "false": "0.0.4",
     "formula-subtract": "^1.0.0",
+    "is-equal-shallow": "^0.1.3",
     "is-null-like": "^1.0.3",
     "is-zero": "^0.1.1",
     "lodash.add": "^3.4.3",

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -53,22 +53,23 @@ describe "filter", ->
 
 describe "padLeft", ->
   it "returns the string padded with spaces if no padding char is given", ->
-    result = umlaut.padLeft('hello', 3)
+    result = umlaut.padLeft('hello', 8)
 
     assert.equal(result, '   hello')
 
   it "returns the string padded with the given char", ->
-    result = umlaut.padLeft('hello', 3, 'y')
+    result = umlaut.padLeft('hello', 8, 'y')
 
     assert.equal(result, 'yyyhello')
 
 describe "padRight", ->
   it "returns the string padded with spaces if no padding char is given", ->
-    result = umlaut.padRight('hello', 3)
+    result = umlaut.padRight('hello', 8)
 
     assert.equal(result, 'hello   ')
 
   it "returns the string padded with the given char", ->
-    result = umlaut.padRight('hello', 3, 'y')
+    result = umlaut.padRight('hello', 8, 'y')
 
     assert.equal(result, 'helloyyy')
+


### PR DESCRIPTION
Our padLeft and padRight functions needed to make more use of the vast npm ecosystem. As you can see from our npm tree these functions are now fully web-scale with 16 modules being used (excluding mocha and coffee-script).

```
├─┬ add-one@1.0.3
│ └─┬ is-integer@1.0.6
│   └─┬ is-finite@1.0.1
│     └── number-is-nan@1.0.0
├── exists@1.0.0
├── false@0.0.4
├── formula-subtract@1.0.0
├── is-null-like@1.0.3
├── is-zero@0.1.1
├── lodash.add@3.4.3
├─┬ string-length@1.0.1
│ └─┬ strip-ansi@3.0.1
│   └── ansi-regex@2.0.0
├── to-string-x@1.0.5
└─┬ validate.io-less-than@1.0.2
  └── validate.io-number@1.0.3
```

For future improvement we should find an alternative to the standard `while` statement and potentially replace the use of `true`. Unfortunately, my attempts to install the true package failed with a strange npm error.
